### PR TITLE
Remove vim-fugitive from the misc plugins list

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -117,4 +117,3 @@ _(The video shows compe + lsp completions and lsp-signature while completion of 
 - [`nvim-comment`](https://github.com/terrortylor/nvim-comment)
 - [`autosave.nvim`](https://github.com/Pocco81/AutoSave.nvim)
 - [`neoscroll.nvim`](https://github.com/karb94/neoscroll.nvim)
-- [`vim-fugitive`](https://github.com/tpope/vim-fugitive)


### PR DESCRIPTION
Remove `"tpope/vim-fugitive"` from the list of misc plugins