### PR TITLE
Fix lua guide link

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -39,7 +39,7 @@ NvChad comes with the following file / folder structure. [An up-to-date & full t
 │   │        └── <many more plugin configs>
 
 ```
-- The file names in the tree with (i) are meant to be ignored , i.e the user doesnt need to look at them. I assume you have basic lua knowledge  The lua code in those files might fret you or look very complex / scare you from nvchad xD. If you're not familiar with lua's syntax then please check [our basic lua guide](http://localhost:3000/getting-started/learn-lua). Dont worry you just need to skim through it. 
+- The file names in the tree with (i) are meant to be ignored , i.e the user doesnt need to look at them. I assume you have basic lua knowledge  The lua code in those files might fret you or look very complex / scare you from nvchad xD. If you're not familiar with lua's syntax then please check [our basic lua guide](getting-started/learn-lua). Dont worry you just need to skim through it. 
 
 ## Walkthrough
 


### PR DESCRIPTION
Lua Guide link on config page pointing to localhost