### PR TITLE
Update lspconfig tsserver config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -420,9 +420,11 @@ M.setup_lsp = function(attach, capabilities)
    -- typescript
 
   lspconfig.tsserver.setup {
+      on_attach = attach
+      capabilities = capabilities,
       cmd = { "typescript-language-server", "--stdio" },
-      filetypes = {"typescriptreact", "typescript.tsx"},
-      root_dir = root_pattern("package.json", "tsconfig.json")
+      filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
+      root_dir = lspconfig.util.root_pattern("package.json", "tsconfig.json")
     }
 end
 


### PR DESCRIPTION
The example for `tsserver` config on the `Setup lsp server` section wasn't working properly. After some tweaks, I could get it to work:

* The config for `tsserver` didn't seem to attach correctly
* `root_pattern` errored out because it was missing from global scope, changed the example to call `lspconfig.util.root_pattern` instead
* Updated the `filetypes` config to match that of [nvim-lspconfig's own example](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#tsserver)