### PR TITLE
Fix typo in example lspconfig

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -420,7 +420,7 @@ M.setup_lsp = function(attach, capabilities)
    -- typescript
 
   lspconfig.tsserver.setup {
-      on_attach = attach
+      on_attach = attach,
       capabilities = capabilities,
       cmd = { "typescript-language-server", "--stdio" },
       filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },


### PR DESCRIPTION
Add missing comma. Copying the example as is raises error in lspconfig file.