### PR TITLE
Fix Extras/TrueZen example config syntax error

### DIFF
--- a/docs/Extras.md
+++ b/docs/Extras.md
@@ -61,7 +61,6 @@
 ```lua
    use {
       "Pocco81/TrueZen.nvim",
-      disable = not status.truezen,
       cmd = {
          "TZAtaraxis",
          "TZMinimalist",


### PR DESCRIPTION
TrueZen example codeblock contains a comment that is not lua-commented and produce a syntax error when following the example. See https://nvchad.github.io/Extras#truezennvim



-- before
```lua
   use {
      "Pocco81/TrueZen.nvim",
      disable = not status.truezen,
      cmd = {
         "TZAtaraxis",
         "TZMinimalist",
         "TZFocus",
      },
      config = function()
          check https://github.com/Pocco81/TrueZen.nvim#setup-configuration (init.lua version)
      end
   }
```

-- after
```lua
   use {
      "Pocco81/TrueZen.nvim",
      disable = not status.truezen,
      cmd = {
         "TZAtaraxis",
         "TZMinimalist",
         "TZFocus",
      },
      config = function()
          -- check https://github.com/Pocco81/TrueZen.nvim#setup-configuration (init.lua version)
      end
   }
```
