### PR TITLE
Update lsp-config server config link

### DIFF
--- a/docs/config/Lsp stuff.md
+++ b/docs/config/Lsp stuff.md
@@ -1,7 +1,7 @@
 ## Setup lsp server
 
 - Skim through [lspconfig repo](https://github.com/neovim/nvim-lspconfig) to get a general overview of how the config looks/works.
-- Then check [lspconfig_config.md](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md) to make sure your language's lsp server is present there.
+- Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's lsp server is present there.
 
 - Create a file in your custom folder. (I would suggest creating plugins dir in custom folder , so /custom/plugins/lspconfig.lua is the config file for this example).
 


### PR DESCRIPTION
The link to where the servers are listed was changed current one points to this 
`Notice: CONFIG.md was moved to doc/server_configurations.md. This notice will be removed after the release of neovim 0.6.`