### PR TITLE
update example config paths

### DIFF
--- a/docs/getting-started/post-install.md
+++ b/docs/getting-started/post-install.md
@@ -40,13 +40,14 @@ In order to set any custom options, you must use the `lua/custom/` directory. Th
 
 ---
 
-NvChad provides `example_init.lua` & `example_chadrc.lua` inside of the `custom` folder.
+NvChad provides `example_init.lua` & `example_chadrc.lua` inside of the `examples` folder.
 
 To start setting up NvChad to your needs, copy these template files:
 
 ```
-cp example_init.lua init.lua
-cp example_chadrc.lua chadrc.lua
+mkdir lua/custom
+cp examples/example_init.lua lua/custom/init.lua
+cp examples/example_chadrc.lua lua/custom/chadrc.lua
 ```
 
 ## Install Treesitter Parser(s)


### PR DESCRIPTION
A little modification to the documentation due to these commits:
- [Delete example_init.lua](https://github.com/NvChad/NvChad/commit/067c6cc7fc4b56fb1aab2946decdd506cc8f7409)
- [Delete example_chadrc.lua](https://github.com/NvChad/NvChad/commit/7114ebd945a96387bfbd00012106fb9efabc9a80)
- [gitignore custom dir | add example configs](https://github.com/NvChad/NvChad/commit/b4da4901382aebb948ff018d63f7206897287643)