### PR TITLE
Remove Telescope media keybind

### DIFF
--- a/docs/config/Default mappings.md
+++ b/docs/config/Default mappings.md
@@ -80,10 +80,7 @@
 | live grep                               | space + f + w |
 | oldfiles                                | space + f + o |
 | themes                                  | space + t + h |
-| &nbsp;                                  |
-| MEDIA PREVIEWS WITHIN TELESCOPE FINDERS |
-| media files                             | space + f + p |
-| &nbsp;                                  |
+| &nbsp;                                  |                          |
 | DISTRACTION FREE & MINIMALIST UI MODE   |
 | ataraxis mode                           | space + z + z |
 | focus mode                              | space + z + f |


### PR DESCRIPTION
This feature was removed and the keybind no longer exists, but it was still in the default-mappings when I was looking through the documentation