### PR TITLE
Remove unnecessary opt key for neoscroll plugin

### DIFF
--- a/docs/Extras.md
+++ b/docs/Extras.md
@@ -11,7 +11,6 @@
 ```lua
   use {
       "karb94/neoscroll.nvim",
-       opt = true,
        config = function()
           require("neoscroll").setup()
        end,


### PR DESCRIPTION
Since the `opt` key is implied by the `setup` key, it is not needed.
Source: https://github.com/wbthomason/packer.nvim#specifying-plugins 