### PR TITLE
refactor: remove unneccesarry lsp configuration

### DIFF
--- a/docs/config/Lsp stuff.md
+++ b/docs/config/Lsp stuff.md
@@ -34,9 +34,6 @@ M.setup_lsp = function(attach, capabilities)
       lspconfig[lsp].setup {
          on_attach = attach,
          capabilities = capabilities,
-         flags = {
-            debounce_text_changes = 150,
-         },
       }
    end
 end
@@ -63,9 +60,6 @@ M.setup_lsp = function(attach, capabilities)
             end
          end,
          capabilities = capabilities,
-         flags = {
-            debounce_text_changes = 150,
-         },
       }
    end
 end
@@ -114,9 +108,6 @@ M.setup_lsp = function(attach, capabilities)
       local opts = {
          on_attach = attach,
          capabilities = capabilities,
-         flags = {
-            debounce_text_changes = 150,
-         },
          settings = {},
       }
 


### PR DESCRIPTION
This is the default in neovim v0.7
> lsp: enable default debounce of 150 ms (#16908) (55a59e5)