### PR TITLE
doc refactor: utils are in the global scope now

### DIFF
--- a/docs/Extras.md
+++ b/docs/Extras.md
@@ -16,7 +16,7 @@
 
        -- lazy loading
        setup = function()
-         require("core.utils").packer_lazy_load "neoscroll.nvim"
+         nvchad.packer_lazy_load "neoscroll.nvim"
        end,
 }
 ```

--- a/docs/config/Custom config.md
+++ b/docs/config/Custom config.md
@@ -59,7 +59,7 @@ M.plugins = {
 - custom/init.lua or any file in custom dir (then load it in custom/init.lua)
 
 ```lua
-local map = require("core.utils").map
+local map = nvchad.map
 
 map("n", "<leader>cc", ":Telescope <CR>")
 map("n", "<leader>q", ":q <CR>")
@@ -76,7 +76,7 @@ map("n", "<C-s>", "<cmd> :w <CR>") -- (check core.mappings.lua first)
 ```lua 
 M.mappings = {
    misc = function()
-      local map = require("core.utils").map
+      local map = nvchad.map
       map("n", "<leader>ss", "<cmd> :w <CR>")
 
       -- or just load your module
@@ -102,7 +102,7 @@ M.plugins = {
          require("core.mappings").telescope()
 
          -- then load your mappings
-         local map = require("core.utils").map
+         local map = nvchad.map
          map("n", "<leader>ts", "<cmd> :Telescope themes <CR>")
       end,
      }


### PR DESCRIPTION
Not 100% sure on `Extras.md` line 19 change - a reviewer should check it before merging

Without this change when I have that was in the docs in my `custom/init.lua`, it fails with this error. Discussion with @siduck is here: https://github.com/NvChad/base46/commit/ef1ae11a980c88aabf0f64814106af15099aac51

<img width="462" alt="withoutChange" src="https://user-images.githubusercontent.com/71017752/167664638-73da840f-2a02-45a6-98cd-2303a1cf94a7.PNG">
