### PR TITLE
Fix meson.nvim typo

### DIFF
--- a/docs/config/Lsp stuff.md
+++ b/docs/config/Lsp stuff.md
@@ -46,7 +46,7 @@ end
 - This is an example of siduck's config :D
 
 ```lua
- ["williamboman/mason"] = {
+ ["williamboman/mason.nvim"] = {
       ensure_installed = {
         -- lua stuff
         "lua-language-server",


### PR DESCRIPTION
Related to https://github.com/NvChad/NvChad/pull/1374.