### PR TITLE
Fix "features" hyperlink

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ module.exports = {
           sidebarId: 'config'
         },
         {
-          to: "Features",
+          to: "features",
           label: "Features",
           position: "left",
           sidebarId: 'config'


### PR DESCRIPTION
Github pages returns "Not found" when visiting page `/Features`, despite local yarn build redirecting to `/Features` correctly.

Github pages can access `/features` (lowercase F) correctly.