### PR TITLE
docs: rewritten part of the docs and other minor imp

### DIFF
--- a/docs/config/Walkthrough.mdx
+++ b/docs/config/Walkthrough.mdx
@@ -1,7 +1,9 @@
 ## How does NvChad work? 
 
-- To continue this topic, first you should understand `vim.tbl_deep_extend` function which we use for merging tables and their values recursively.
-- We use `vim.tbl_deep_extend` to merge 2 tables usually, the syntax looks like this : 
+### Understanding the basics
+
+Before getting into the this topic, first you should understand the `vim.tbl_deep_extend` function which is used for merging tables and their values recursively.  
+The function `vim.tbl_deep_extend` is normally used to merge 2 tables, and its syntax looks like this: 
 
 ```lua
 -- table 1
@@ -15,19 +17,18 @@ local someone = {
     name = "siduck",
 }
 
+-- "force" will overwrite equal values from the someone table over the person table
 local result = vim.tbl_deep_extend("force", person, someone)
 
--- "force" will use values from someone table to override them on person table
 -- result : 
-
 {
-    name = "siduck",
+    name = "siduck", -- as you can see, name has been overwritten
     age = 19,
 }
 ```
 
-<br/>
-- Lets look at some complex tables : 
+<br />
+Its usage can even be used in more complex tables. As said, it works recursively, which means that it will apply the same behaviour for nested table values: 
 
 ```lua
 local person = {
@@ -56,7 +57,7 @@ local result = vim.tbl_deep_extend("force", person, someone)
 ```
 <br/>
 
-And the result is : 
+The resulting table will have merged each property from the tables, and the same for the `skilsl` and `distros_used` values:
 
 ```lua
 {
@@ -73,14 +74,15 @@ And the result is :
    }
 }
 
--- tbl_deep_extend function merges values recursively, but if there's an array ( list ) then it wont merge the the list tables. 
+-- tbl_deep_extend function merges values recursively, but if there's an array (list), it won't merge the list tables. 
 
--- Example : table 1 has  {"python", "java", "c++"} and table 2 has {"js","lua"}, now you might be wondering that it should merge it like this : 
-
--- { "python", "java", "c++", "lua"} , But no! thats wrong, the result will be only {"js","lua"}.
+-- Example: the first table has {"python", "java", "c++"} and the second table has {"js","lua"}. Now you might be wondering that it should merge it like this: 
+-- { "python", "java", "c++", "lua"}
+-- But no! thats wrong, the result will be only {"js","lua"}
 ```
+
 <br/>
-- tbl_deep_extend merges dicts tables recursively i.e tables which have key/value pair but not lists ( arrays )
+To sum up, `tbl_deep_extend` merges dictonary tables recursively (i.e tables which have `key/value` pair but not lists).
 
 ## Config Structure
 
@@ -110,25 +112,29 @@ And the result is :
 ```
 <br/>
 
-- **init.lua -** runs everything
-- **core/default_config -** returns a table for whole nvchad config 
-- **core/mappings -** default mappings
-- **core/init -** globals, nvim options, commands, autocmds 
-- **core/utils -** helpful functions
-- The custom dir contains all the user configurations, `chadrc.lua` and `init.lua` in `custom dir` are the main files.
+- **`init.lua` -** runs everything
+- **`core/default_config` -** returns a table for whole nvchad config 
+- **`core/mappings` -** default mappings
+- **`core/init` -** globals, nvim options, commands, autocmds 
+- **`core/utils` -** helpful functions
+- The custom dir will contain all the user configuration. `chadrc.lua` and `init.lua` in `custom` are the main files.
 
 ![GitHub Logo](/illustrations/config_nutshell.webp)
 
-From now whenever we talk about paths, do know that they're relative to the lua folder in your nvim config.
+From now on, whenever we talk about paths, keep in mind that they're relative to the `lua` folder in your `nvim` config (by default it should be `~/.config/nvim/`).
 
-- To extend nvchad the user should use 2 files in the custom dir ( chadrc.lua and init.lua ). You shouldn't make changes outside the custom dir.
-- The chadrc file is meant to override the `core/default_config.lua` file so check it to know all the available options.
+- To extend NvChad, the user should use 2 files in the custom dir (`chadrc.lua` and `init.lua`). It is not recommended to make changes outside the `custom` dir. The main reason is because NvChad provides an utility that will auto-update by basically pulling the changes from git. Any other file outside the `custom` dir will be treated as a change by `git`, meaning that NvChad will not be able to fast-forward the pull.
+- The `chadrc` file overrides the `core/default_config.lua` file. In order to know what options can you change, make sure the check the [`default_config.lua`](https://github.com/NvChad/NvChad/blob/v2.0/lua/core/default_config.lua) file.
 
 ## Themes
 
-- `<leader> + th`   (`<leader>` is space key in our config)
+You can see all the themes with the following keymap: `<leader> + th`.
+
+> The `leader` key is the `<space>` in NvChad. 
 
 ## Mappings
+
+If you want to know all the keymaps, you can run the following comands in the nvim `Cmd`:
 
 - `Telescope keymaps` 
 - `NvCheatsheet`

--- a/docs/config/Walkthrough.mdx
+++ b/docs/config/Walkthrough.mdx
@@ -57,7 +57,7 @@ local result = vim.tbl_deep_extend("force", person, someone)
 ```
 <br/>
 
-The resulting table will have merged each property from the tables, and the same for the `skilsl` and `distros_used` values:
+The resulting table will have merged each property from the tables, and the same for the `skills` and `distros_used` values:
 
 ```lua
 {

--- a/docs/config/format_lint.mdx
+++ b/docs/config/format_lint.mdx
@@ -1,7 +1,11 @@
-## Install null-ls.nvim
+## Install `null-ls.nvim`
 
-- Dependencies load after the original plugin ( lspconfig in our case ).
-- Null-ls is loaded after lspconfig as lspconfig is lazyloaded.
+It is recommended that you install `null-ls` due to its simplicity and ease to set up. With that, keep in mind that:
+
+- Dependencies are loaded after the original plugin (`lspconfig` in NvChad's case).
+- `null-ls` is loaded after `lspconfig` as `lspconfig` is lazy-loaded.
+
+Here's a possible install configuration for `null-ls`:
 
 ```lua
 {
@@ -23,10 +27,12 @@
 
 ## Null-ls config
 
-- Check [null-ls builtins](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md) to get exact names for formatters, linters etc.
-- **`custom/configs/null-ls.lua`**
+Make sure to check [`null-ls` builtins](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md) to get exact names for formatters, linters etc.
+
+Here's an exmple configuration for `null-ls`, following the NvChad file directory structure:
 
 ```lua
+-- custom/configs/null-ls.lua
 
 local null_ls = require "null-ls"
 
@@ -47,6 +53,8 @@ null_ls.setup {
 ```
 <br/>
 
-- Format code : `<leader> + fm`
-- linter/formatter/debugger listed in your null-ls config must be downloaded via mason or system wide.
-- Make sure LSP server for your filetype is active for the relevant null-ls formatter / linter to work.
+Other things to take into account when configuring `null-ls` for NvChad:
+
+- This shortcut is defined for code formatting: `<leader> + fm`.
+- The linter, formatter or debugger that you will use in `null-ls` configuration, has to be downloaded via `mason` or system wide. **NvChad does ont come with any pre-installed linter, debugger nor formatter**.
+- Make sure the LSP servers for the filetypes are active for the relevant `null-ls` formatter and/or linter to work.

--- a/docs/config/lsp.mdx
+++ b/docs/config/lsp.mdx
@@ -1,6 +1,6 @@
 ## Setup lsp server
 
-Before starting, it is strongly recommended that you walk trhough the LSP configuration: [`lspconfig` repository](https://github.com/neovim/nvim-lspconfig). Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's LSP server is present there. You can install LSP servers manually or through `mason.nvim` (recommended option).
+Before starting, it is strongly recommended that you walk through the LSP configuration: [`lspconfig` repository](https://github.com/neovim/nvim-lspconfig). Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's LSP server is present there. You can install LSP servers manually or through `mason.nvim` (recommended option).
 
 
 ```lua

--- a/docs/config/lsp.mdx
+++ b/docs/config/lsp.mdx
@@ -1,11 +1,10 @@
 ## Setup lsp server
 
-- Skim through [lspconfig repo](https://github.com/neovim/nvim-lspconfig) to get a general overview of how the config works.
-- Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's lsp server is present there.
+Before starting, it is strongly recommended that you walk trhough the LSP configuration: [`lspconfig` repository](https://github.com/neovim/nvim-lspconfig). Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's LSP server is present there. You can install LSP servers manually or through `mason.nvim` (recommended option).
 
 
 ```lua
--- We are just modifying lspconfig's config spec
+-- In order to modify the `lspconfig` configuration:
 {
   "neovim/nvim-lspconfig",
    config = function()
@@ -14,10 +13,11 @@
    end,
 },
 ```
-<br/>
+
+<br />
 
 ```lua
--- custom.configs.lspconfig
+-- custom/configs/lspconfig.lua
 local on_attach = require("plugins.configs.lspconfig").on_attach
 local capabilities = require("plugins.configs.lspconfig").capabilities
 
@@ -30,27 +30,22 @@ for _, lsp in ipairs(servers) do
     capabilities = capabilities,
   }
 end
-```
-<br/>
 
-```lua
---  Without the loop it would look like this 
-
-lspconfig.html.setup {
-  on_attach = on_attach,
-  capabilities = capabilities,
-}
-
-lspconfig.cssls.setup {
-  on_attach = on_attach,
-  capabilities = capabilities,
-}
+-- Without the loop, you would have to manually set up each LSP 
+-- 
+-- lspconfig.html.setup {
+--   on_attach = on_attach,
+--   capabilities = capabilities,
+-- }
+--
+-- lspconfig.cssls.setup {
+--   on_attach = on_attach,
+--   capabilities = capabilities,
+-- }
 ```
 ## Mason.nvim
 
-- The Mason.nvim plugin is used to install lspservers, formatters, linters, and debug adapters. 
-- It's better to list all your required packages and put them into your Mason override config.
-- Find the exact name of your packages from the `:Mason` window
+The `mason.nvim` plugin is used to install LSP servers, formatters, linters, and debug adapters. It's better to list all your required packages and put them into your Mason override config, so they are automatically installed when running `MasonInstallAll`. You can find the exact name of the LSP packages using `:Mason`, that will open a window.
 
 ```lua
  {
@@ -65,7 +60,11 @@ lspconfig.cssls.setup {
     },
   }
 ```
-<br/>
 
-- Reopen nvim & run the `:MasonInstallAll` command. This will install the listed binaries in the `ensure_installed` table.
-- This only downloads the binaries. The lsp server/formatters won't run automatically. You need to configure a custom lspconfig and possibly some plugin like null-ls/neoformat etc for the formatters to work.
+<br />
+
+After modifying `mason`'s configuration, do:
+
+- Run `nvim +MasonInstallAll`. This will install the listed binaries in the `ensure_installed` table.
+
+Once the binaries are installed, you will have to configure them to properly work with LSP. NvChad does not provide any language configuration aside from lua.

--- a/docs/config/mappings.mdx
+++ b/docs/config/mappings.mdx
@@ -1,28 +1,31 @@
-
 ## Overview
 
-- C = <kbd> Ctrl </kbd>
-- leader = <kbd> Space </kbd>
-- A = <kbd> alt </kbd>
-- S = <kbd> shift </kbd>
-- Defaults are defined in `core.mappings`. 
-- `NvCheatsheet` or `Telescope keymaps` to list all mappings.
+The mapping configuration uses the nvim name shorcuts as:
+
+- `<C>`: <kbd>Ctrl</kbd>
+- `<leader>` = <kbd>Space</kbd>
+- `<A>` = <kbd>alt</kbd>
+- `<S>` = <kbd>shift</kbd>
+- The default mappings are defined in `core.mappings` (`core/mappings.lua). 
+- Alternatively, you can use `NvCheatsheet` or `Telescope keymaps` to list all mappings.
 
 ## Mapping format
-- opts here is completely optional
-- Mapping description makes your keybind listed in NvCheatsheet window
 
+In order to list custom shortcuts in NvCheatsheet, make sure to use the following format
 
 ```lua
+-- opts is an optional parameter
 ["keys"] = {"action", "description", opts = {}},
 
 ["<C-n>"] = {"<cmd> NvimTreeToggle <CR>", "Toggle nvimtree"},
-["<leader>ff"] = {":Telescope <CR>", "Telescope"},  -- can : instead of <cmd> 
+-- In this case : equals <cmd>
+["<leader>ff"] = {":Telescope <CR>", "Telescope"},   
 
--- opts can have : buffer, silent, noremap, nowait etc
--- all standard key binding opts are supported. 
+-- opts can have the props: buffer, silent, noremap, nowait and so on.
+-- All standard key binding opts are supported. 
 [";"] = { ":", "enter cmdline", opts = { nowait = true } },
 
+-- For a more complex keymap
 ["<leader>tt"] = {
   function()
      require("base46").toggle_transparency()
@@ -33,20 +36,23 @@
 
 ## Add new mappings
 
-- This is the mappings structure of core.mappings and your custom mappings.
-- You need to put your mappings into `modes` like n, v, i, t, etc.
-- n = normal, i = insert and so on.
+In order to add or customize the mappings, make sure that you follow the expected file structure for NvChad. The default mappings are loaded from `core.mappings`, and it is recommende that you place your mappings inside `custom.mappings`. Remember that the mappings **must** have a vim mode: `n` (for normal), `v` (for visual), `i` (for insert) and so on.
+
+Inside your `chadrc` file, make sure you add: 
+
 ```lua
-M.mappings = require "custom.mappings" -- chadrc file
+-- custom/chadrc.lua
+M.mappings = require "custom.mappings"
+-- You can change the file location, as long as you update the previous line accordingly
 ```
-<div pb-2></div> 
 
-- **`custom/mappings.lua`**
+Then, in your `custom.mappings` configuration, add the wanted mappings:
 
 ```lua
+-- custom/mappings.lua
 local M = {}
 
--- add this table only when you want to disable default keys
+-- In order to disable a default keymap, use
 M.disabled = {
   n = {
       ["<leader>h"] = "",
@@ -54,6 +60,7 @@ M.disabled = {
   }
 }
 
+-- Your custom mappings
 M.abc = {
   n = {
      ["<C-n>"] = {"<cmd> Telescope <CR>", "Telescope"}
@@ -62,27 +69,27 @@ M.abc = {
 
   i = {
      ["jk"] = { "<ESC>", "escape insert mode" , opts = { nowait = true }},
-    -- more keys!
+    -- ...
   }
-}
-
-M.xyz = {
-  -- stuff
 }
 
 return M
 ```
 
-<br/>
-- Be sure to maintain a table structure similar to core.mappings.
-- Mappings will be automatically loaded. You don't need to load them manually.
+<br />
+
+A couple of recommendations: 
+
+- Be sure to maintain a table structure similar to the one in `core.mappings`.
+- Mappings will be automatically loaded. You don't need to load them manually!
 
 ## Manually load mappings
 
+Even though it is not required, you can manually load your mappings with:
+
 ```lua
--- your mappings table
-M.someplugin = {
-  plugin = true,
+M.some_plugin_name = {
+  plugin = true, -- <- Important!
 
   n = {
      ["<C-n>"] = {"<cmd> Telescope <CR>", "Telescope"}

--- a/docs/config/nvchad_ui.mdx
+++ b/docs/config/nvchad_ui.mdx
@@ -1,17 +1,16 @@
 ## Statusline & tabufline 
 
-- We use our own [plugin](https://github.com/NvChad/ui) for statusline & tabufline and it has some options.
-- The default config: (You must know that every plugin's default config is just a table).
+We use our own [plugin](https://github.com/NvChad/ui) for `statusline` and `tabufline`. The default config is (keep in mind that every plugin's default config is just a table):
 
 ```lua
 M.ui = {
-  ... some options
+  -- ...other options
 
   statusline = {
     theme = "default", -- default/vscode/vscode_colored/minimal
 
-    -- default/round/block/arrow separators work only for default statusline theme
-    -- round and block will work for minimal theme only
+    -- default/round/block/arrow (separators work only for "default" statusline theme;
+    -- round and block will work for the minimal theme only)
     separator_style = "default",
     overriden_modules = nil,
   },
@@ -21,58 +20,59 @@ M.ui = {
     overriden_modules = nil,
   },
 
-  ... some options
+  -- ...other options
 }
 ```
 
-### Override statusline modules 
+### Override `statusline` modules 
 
-- Add this in your plugin overrides section:
+It is also possible to override the plugin's configuration:
 
 ```lua
-statusline = {
-  overriden_modules = function()
-    local st_modules = require "nvchad_ui.statusline.default"
-    -- this is just default table of statusline modules
-
-    return {
-      mode = function()
-        return st_modules.mode() .. " bruh "
-      end,
-    }
-  end,
-},
-
+M.ui = {
+  statusline = {
+    overriden_modules = function()
+      local st_modules = require "nvchad_ui.statusline.default"
+      -- this is just default table of statusline modules
+  
+      return {
+        mode = function()
+          return st_modules.mode() .. " bruh "
+        end,
+      }
+    end,
+  },
+}
 ```
 <br/>
 
-- First, check the list of modules in [our statusline modules file](https://github.com/NvChad/ui/blob/main/lua/nvchad_ui/statusline/modules.lua).
-- In the above code, you can see that we wanted to print "bruh" next to the mode module in the statusline.
-- To add highlight group to your text 
+It is recommended to check the list of modules in [our `statusline` modules file](https://github.com/NvChad/ui/blob/main/lua/nvchad_ui/statusline/modules.lua). In the above code, you can see that we want to print "bruh" next to the mode module, in the statusline. In order to add highlight group to your text, do:
 
 ```lua
-"#BruhHl%" .. " bruh "
--- so the highlight group here is BruhHl
+"#BruhHl%" .. " bruh " -- the highlight group here is BruhHl
 ```
 
-### Override tabufline modules
+### Override `tabufline` modules
 
-- Overriding tabufline modules is the same as statusline
-- This example is for overriding the modules in tabufline:
+The configuration for overriding `tabufline` is the same as in `statusline`:
 
 ```lua
-tabufline = {
-   overriden_modules = function()
-     local modules = require "nvchad_ui.tabufline.modules"
-
-     return {
-       buttons = function()
-         return modules.buttons() .. " my button "
-       end,
-       -- or buttons = "" , this will disable the buttons
-     }
-   end,
- },
+M.ui = {
+  tabufline = {
+     overriden_modules = function()
+       local modules = require "nvchad_ui.tabufline.modules"
+  
+       return {
+         buttons = function()
+           return modules.buttons() .. " my button "
+         end,
+         -- or buttons = "" , this will disable the buttons
+       }
+     end,
+  },
+}
 ```
+
 <br/>
-- First, check the list of modules in [our tabufline modules file](https://github.com/NvChad/ui/blob/main/lua/nvchad_ui/tabufline/modules.lua).
+
+Again, check the list of modules in [our tabufline modules file](https://github.com/NvChad/ui/blob/main/lua/nvchad_ui/tabufline/modules.lua).

--- a/docs/config/options.mdx
+++ b/docs/config/options.mdx
@@ -1,14 +1,7 @@
 ## Override default options
 
-- Put the options in `custom/init.lua`.
-- New options can put in the same file as well. 
-
-## Autocmds & Globals
-
-- Load these in the `custom/init.lua` file.
+In order to override default options, it is recommended to put the options in `custom/init.lua`. New options can put in the same file as well. `autocmds` and `globals` can also be put inside `custom/init.lua`
 
 ## Snippets 
 
-- NvChad uses luasnip for snippets.
-- For custom snippets you can add the below global.
-- `vim.g.luasnippets_path = "your snippets path"`
+NvChad uses `luasnip` for snippets. In order to add custom snippets, you can pass the path to your snippets on: `vim.g.luasnippets_path = "your snippets path"`

--- a/docs/config/plugins.mdx
+++ b/docs/config/plugins.mdx
@@ -1,42 +1,36 @@
 ## Overview
 
-- NvChad uses [lazy.nvim](https://github.com/folke/lazy.nvim) for plugins management so its syntax is valid.
-- Basically NvChad expects a user plugin table, which then gets merged with the default plugins table.
-
+NvChad uses [lazy.nvim](https://github.com/folke/lazy.nvim) for plugins management. Basically, NvChad expects a user plugin table, which then gets merged with the default plugins table. You can find the table in: [`lua/plugins/init.lua`](https://github.com/NvChad/NvChad/blob/v2.0/lua/plugins/init.lua).
 
 ## Lazy loading
 
-- We lazy load almost 95% of the plugins, so we expect you to lazy load the plugins as well! As its efficient in reducing startuptime. We don't want users making NvChad slow just because they didn't lazy load plugins they've added!
+We lazy load almost 95% of the plugins, so we expect and recommend you to lazy load the plugins as well, as its efficient in reducing startuptime. We don't want users making NvChad slow just because they didn't lazy load plugins they've added!
 
 ### Tips
 
-- <strong> cmd : </strong> If a plugin loads on commands then use the `cmd` spec, For ex: trouble.nvim plugin opens when we run "Trouble" command, so now I'd just write the word "Trouble" in the cmd spec of trouble.nvim plugin definition.
-- <strong> event : </strong> Use this spec if you want to load a plugin on certain vim event ( check :h events ). Cmp.nvim plugin is useful when we're in insert mode, so I lazyload it at "InsertEnter" event. 
+- **`cmd`:** If a plugin loads on commands, then use the `cmd` spec. For example, the `trouble.nvim` plugin opens when the command `Trouble` is run. Therefore, we would write the word `Trouble` in the `cmd` spec of the `trouble.nvim` plugin configuration.
+- **`event`:** Use this spec if you want to load a plugin on certain vim event (check `:h events`). For example, the `cmp.nvim` plugin is useful when we're in insert mode, so it is lazyload it at the `InsertEnter` event. 
 
-- There are more specs through which you could do lazyloading like <strong> ft, cond, keys </strong>.
+There are more specs through which you could do lazy-loading like `ft`, `config` and `keys`.
 
 ## Managing custom plugins
-- In NvChad (lazy = true) is set to all plugins, so if you want a plugin to be enabled on startup, do (lazy = false)
-- Some examples : 
 
-**`custom/chadrc.lua`**  :
+All NvChad default plugins will have `lazy = true` set. Therefore, if you want a plugin to be enabled on startup, change it to `lazy = false`.
+
+<br/>
+
+It is recommended that you avoid saving any files in the `custom/plugins/*` directory. Our system utilizes the import feature provided by`lazy.nvim`, which imports all files in a directory and expects each file to return plugin tables. This behavior is undesirable for our purposes, so it is recommendeed to create a single file named `custom/plugins.lua`. This file will be imported by `lazy.nvim`, and no other files in the directory will be processed.
+
 ```lua
+-- custom/chadrc.lua
 M.plugins = "custom.plugins"
-```
-<br/>
 
-- Do know you shouldnt save anything in `custom/plugins/` dir. We're using the import feature provided by lazy.nvim so it'll import all the files in a dir and expect each file to return plugin tables etc which we dont want so we just create "custom/plugins.lua" file and then lazy will import only this file.
-
-<br/>
-
-**`custom/plugins.lua`** :
-```lua
+-- custom/plugins.lua
 return {
-
   -- Install plugin
   { "elkowar/yuck.vim" , lazy = false },
 
-  -- Using more plugin specs like cmd etc
+  -- You can use any plugin specification from lazy.nvim
   {
     "Pocco81/TrueZen.nvim",
     cmd = { "TZAtaraxis", "TZMinimalist" },
@@ -45,7 +39,7 @@ return {
     end,
   }
 
-  -- opts overrides default plugin config's option
+  -- opts overrides all default plugin configurations
   {
     "nvim-treesitter/nvim-treesitter",
     opts = {
@@ -53,8 +47,8 @@ return {
     },
   },
 
-  -- Here we wrap opts with a function because its loading cmp module
-  -- If we didnt wrap with function then the code will run on startup
+  -- It is also possible to wrap opts with a function because it is required
+  -- to load the cmp module. If it wasn't done, then the code would run on startup
    {
     "hrsh7th/nvim-cmp",
     opts = function()

--- a/docs/config/theming.mdx
+++ b/docs/config/theming.mdx
@@ -74,7 +74,6 @@ M.base_16 = {
 }
 
 M.type = "dark" -- this is required or your theme will break on loading!
-vim.opt.bg = "dark" -- or light 
 
 return M
 ```

--- a/docs/config/theming.mdx
+++ b/docs/config/theming.mdx
@@ -1,16 +1,13 @@
 ## Override default highlight groups
 
-- Make sure you use a valid highlight group!
-- Check your theme colors in this dir:
+It is possible to overwrite the highlighting groups for the selected theme:
 
-```shell
-~/.local/share/nvim/lazy/base46/lua/base46/integrations
-```
+- Make sure you use a valid highlight group
+- Check your theme colors in this dir: `~/.local/share/nvim/lazy/base46/lua/base46/integrations`
+
 <br/>
 
-- In your theme file, for instance onedark.lua, only the variables from base_30 can be used in overriding your custom highlight groups. 
-- You can even use hex colors in the fg/bg field, but it's preferable to use variable names (for instance: blue, darker_black, one_bg, etc.) from your theme file as these will look better.
-- No need to write hex colors manually!
+When modifying the custom highlight groups in your theme file, such as "onedark.lua", it is important to note that only the variables from "base_30" can be used for this purpose. Although hex colors can also be used in the "fg/bg" field, it is recommended to utilize the variable names (e.g. "blue", "darker_black", "one_bg", etc.) from your theme file as they will provide a better aesthetic. This way, there is no need to manually input the hex colors.
 
 ```lua
 M.ui = {
@@ -18,8 +15,7 @@ M.ui = {
       Pmenu = { bg = "white" },
       -- Pmenu = { bg = "#ffffff" }, this works too
 
-
-      MyHighlightGroup = {
+      MyHighlightGroup = { -- custom highlights are also allowed
          fg = "red",
          bg = "darker_black"
       }
@@ -27,16 +23,14 @@ M.ui = {
 }
 ```
 
-### Add new highlight groups
-
-- The same method can be used as above, but instead of `hl_override`, you add in `hl_add` field in chadrc.
+In order to add custom highlights, thee same method can be used as above. However, instead of using `hl_override`, you have to use the `hl_add` field in chadrc.
 
 ## Customize themes
 
-- You can edit theme colors from the `changed_themes` table
+If you just want to customize an already existing theme, you can change the following configuration:
+
 ```lua
 M.ui = {
-
    changed_themes = {
       onedark = {
          base_16 = {
@@ -57,12 +51,17 @@ M.ui = {
 
 ### Local themes
 
-(WARNING: Do this at your own risk because you might not be able to make nvchad themes like siduck.)
-- Default themes are in our base46 repo's themes dir.
-- Any nvchad theme structure looks like this:
+> (WARNING: Do this at your own risk because you might not be able to make nvchad themes like siduck.)
+
+Keep in mind that:
+
+- Default themes can be found in our [`base46`](https://github.com/NvChad/base46) repository.
+
+Here is the default structure for NvChad themes:
 
 ```lua
--- theme file is custom/themes/siduck.lua
+-- place the file in custom/themes/<theme-name>.lua
+-- for example: custom/themes/siduck.lua
 
 local M = {}
 
@@ -74,12 +73,15 @@ M.base_16 = {
     -- my base16 colors
 }
 
+M.type = "dark" -- this is required or your theme will break on loading!
 vim.opt.bg = "dark" -- or light 
+
 return M
 ```
 
 <br/>
-- Make sure to use the exact variable names!
+
+Finally, you just need to use the same name as the file!
 
 ```lua
 M.ui = {


### PR DESCRIPTION
After migrating myself from `v1.0` to `v2.0`, I felt that the docs were a bit hard to follow. The idea is to try to provide a more understandable documentation for newcomers and people who are trying to migrate from `v1.0` as I did.

In this PR, I have only modified the `Custom config` section from the documentation.