### PR TITLE
fix(docs): typo in plugins.lua snippet

### DIFF
--- a/src/routes/(index)/docs/config/lsp.mdx
+++ b/src/routes/(index)/docs/config/lsp.mdx
@@ -4,7 +4,7 @@ Before starting, it is strongly recommended that you walk through the LSP config
 
 Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's LSP server is present there. 
 
-- **custom/plugina.lua**
+- **custom/plugins.lua**
 
 ```lua
 -- In order to modify the `lspconfig` configuration:

--- a/src/routes/(index)/docs/config/lsp.mdx
+++ b/src/routes/(index)/docs/config/lsp.mdx
@@ -12,7 +12,7 @@ Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/b
   "neovim/nvim-lspconfig",
    config = function()
       require "plugins.configs.lspconfig"
-      require "custom.plugins.lspconfig"
+      require "custom.configs.lspconfig"
    end,
 },
 ```


### PR DESCRIPTION
This PR adds in a typo for the LSP instructions where the filename was `plugina.lua` instead of `plugins.lua`