### PR TITLE
docs: remove extra angular bracket from leader description

### DIFF
--- a/src/routes/(index)/docs/config/walkthrough.mdx
+++ b/src/routes/(index)/docs/config/walkthrough.mdx
@@ -142,7 +142,7 @@ From now on, whenever we talk about paths, keep in mind that they're relative to
 
 You can see all the themes with the following keymap: `<leader> + th`.
 
-> The `leader` key is the  <kbd>space></kbd>  in NvChad. 
+> The `leader` key is the  <kbd>space</kbd>  in NvChad. 
 
 ## Mappings
 


### PR DESCRIPTION
I think the `>` was added accidentally 