### PR TITLE
Lower chased 'd' in NvDash command

### DIFF
--- a/src/routes/(index)/docs/features.mdx
+++ b/src/routes/(index)/docs/features.mdx
@@ -58,7 +58,7 @@
 ## Dashboard
 
 - Nvdash is NvChad's minimal dashboard module, It's very simple at this stage and will get more features in the future!
-- Command to run it `NvDash`, its disabled on startup, check the default_config.lua for its syntax and override it from chadrc.
+- Command to run it `Nvdash`, its disabled on startup, check the default_config.lua for its syntax and override it from chadrc.
 
 ![nvdash](/features/nvdash.webp)
 


### PR DESCRIPTION
I believe that the d in `NvDash` should be lower case because the current command gives an error. (See attached pictures)

![screen-2023-04-09-22:46:37](https://user-images.githubusercontent.com/34864484/230795900-3fa7fc61-131d-43f7-8908-04a61eaf5cfb.jpg)

![screen-2023-04-09-22:46:56](https://user-images.githubusercontent.com/34864484/230795907-e1c305a6-8a86-4ce9-b45f-51dcc91ed9fb.jpg)
