### PR TITLE
typo: toggle_themes -> toggle_theme

### DIFF
--- a/src/routes/(index)/docs/api.mdx
+++ b/src/routes/(index)/docs/api.mdx
@@ -40,7 +40,7 @@ require("base46").toggle_transparency()
 - Used to toggle between 2 themes, make sure that you have `theme_toggle` option set in your chadrc.
 
 ```lua
-require("base46").toggle_themes()
+require("base46").toggle_theme()
 ```
 
 ## Close all buffers


### PR DESCRIPTION
`toggle_themes()` didn't seem to work for me. Referring below code, it should be `toggle_theme()` which works great!
https://github.com/NvChad/base46/blob/59732cab28054386545610c53a0fa05c5416942e/lua/base46/init.lua#L161