### PR TITLE
Update links to tabufline/statusline

### DIFF
--- a/src/routes/(index)/docs/config/nvchad_ui.mdx
+++ b/src/routes/(index)/docs/config/nvchad_ui.mdx
@@ -47,7 +47,7 @@ M.ui = {
 ```
 <br/>
 
-It is recommended to check the list of modules in [our `statusline` modules file](https://github.com/NvChad/ui/blob/main/lua/nvchad_ui/statusline/modules.lua). In the above code, you can see that we want to print "bruh" next to the mode module, in the statusline. In order to add highlight group to your text, do:
+It is recommended to check the list of modules in [our `statusline` modules file](https://github.com/NvChad/ui/blob/v2.0/lua/nvchad_ui/statusline). In the above code, you can see that we want to print "bruh" next to the mode module, in the statusline. In order to add highlight group to your text, do:
 
 ```lua
 "%#BruhHl#" .. " bruh " -- the highlight group here is BruhHl
@@ -76,4 +76,4 @@ M.ui = {
 
 <br/>
 
-Again, check the list of modules in [our tabufline modules file](https://github.com/NvChad/ui/blob/main/lua/nvchad_ui/tabufline/modules.lua).
+Again, check the list of modules in [our tabufline modules file](https://github.com/NvChad/ui/blob/v2.0/lua/nvchad_ui/tabufline).


### PR DESCRIPTION
Firstly, thanks for the awesome work on this config!

I was following the docs trying to add a custom statusline element, and I was completely stumped as to why copying the exact source code from the file linked in the statusline docs was leading to a completely different result, until I realized that the link in the docs was to the main branch, while I was using v2.

I was unsure whether it'd make sense to make this change, as it would alienate the people who are still using v1, but since everywhere else in the docs kinda assumes the user is using v2 (for example, [manage plugins](https://nvchad.com/docs/config/plugins) assumes lazy.nvim), I felt it would make more sense to have the whole docs being consistent at version 2. Ideally there would be different docs for each version, but that's a much larger project.