### PR TITLE
Add missing trailing comma

### DIFF
--- a/src/routes/(index)/docs/config/mappings.mdx
+++ b/src/routes/(index)/docs/config/mappings.mdx
@@ -67,7 +67,7 @@ M.abc = {
   n = {
      ["<C-n>"] = {"<cmd> Telescope <CR>", "Telescope"},
      ["<C-s>"] = {":Telescope Files <CR>", "Telescope Files"} 
-  }
+  },
 
   i = {
      ["jk"] = { "<ESC>", "escape insert mode" , opts = { nowait = true }},


### PR DESCRIPTION
While setting up this key binding, I was referring to this document: https://nvchad.com/docs/config/mappings

```lua
M.save = {
  n = {
    ["<C-S>"] = {":update<CR>", "Save File in Normal mode"}
  },

  i = {
    ["<C-S>"] = {"<C-C>:update<CR>", "Save File in Insert Mode"}
  },

  v = {
    ["<C-S>"] = {"<C-O>:update<CR>"}
  }
}
```

I am still a beginner in lua so I missed that comma, since documentation didn't have it when defining key binding in `normal` and `insert` mode.