### PR TITLE
Fixed typo in plugins.mdx

### DIFF
--- a/src/routes/(index)/docs/config/plugins.mdx
+++ b/src/routes/(index)/docs/config/plugins.mdx
@@ -16,7 +16,7 @@ All NvChad default plugins will have `lazy = true` set. Therefore, if you want a
 
 It is recommended that you avoid saving any files in the `custom/plugins/*` directory.
 
-> Our system utilizes the import feature provided by`lazy.nvim`, which imports all files in a directory and expects each file to return plugin tables. This behavior is undesirable for our purposes, so it is recommendeed to create a single file named **custom/plugins.lua**. This file will be imported by `lazy.nvim`, and no other files in the directory will be processed.
+> Our system utilizes the import feature provided by`lazy.nvim`, which imports all files in a directory and expects each file to return plugin tables. This behavior is undesirable for our purposes, so it is recommended to create a single file named **custom/plugins.lua**. This file will be imported by `lazy.nvim`, and no other files in the directory will be processed.
 
 <br/>
 - **custom/chadrc.lua**


### PR DESCRIPTION
just removed an 'e'