### PR TITLE
Fix heading for "Invert Value" on the page "Learn basic Lua"

### DIFF
--- a/src/routes/(index)/docs/quickstart/learn-lua.mdx
+++ b/src/routes/(index)/docs/quickstart/learn-lua.mdx
@@ -95,7 +95,7 @@ end
 -- result: over 18
 ```
 
-**Invert Value**
+### Invert Value
 
 You can also invert a value with the **not** keyword:
 


### PR DESCRIPTION
I changed the heading for "Invert Value" from just bold to h3.

Before:
```md
**Invert Value**
```

But I think this should be a heading.