### PR TITLE
fix: remove space from install snippet

### DIFF
--- a/src/components/docpage/install.jsx
+++ b/src/components/docpage/install.jsx
@@ -54,8 +54,8 @@ export default () => {
       </div>
 
       {typeof (oscmd()) === "string"
-        ? <pre class="hljs"> {oscmd()}</pre>
-        : oscmd().map((x) => <pre class="hljs"> {x}</pre>)}
+        ? <pre class="hljs">{oscmd()}</pre>
+        : oscmd().map((x) => <pre class="hljs">{x}</pre>)}
     </div>
   );
 };


### PR DESCRIPTION
Currently the install snippet has a space at the beginning, making it just that harder to install.