### PR TITLE
Minor documentation improvements

### DIFF
--- a/src/routes/(index)/docs/config/plugins.mdx
+++ b/src/routes/(index)/docs/config/plugins.mdx
@@ -14,7 +14,7 @@ We lazy load almost 95% of the plugins, so we expect and recommend you to lazy l
 
 All NvChad default plugins will have `lazy = true` set. Therefore, if you want a plugin to be enabled on startup, change it to `lazy = false`.
 
-It is recommended that you avoid saving any files in the `custom/plugins/*` directory.
+It is recommended that you avoid saving any files in the `lua/plugins/*` directory.
 
 > Our system utilizes the import feature provided by`lazy.nvim`, which imports all files in a directory and expects each file to return plugin tables. This behavior is undesirable for our purposes, so it is recommended to create a single file named **custom/plugins.lua**. This file will be imported by `lazy.nvim`, and no other files in the directory will be processed.
 

--- a/src/routes/(index)/docs/config/walkthrough.mdx
+++ b/src/routes/(index)/docs/config/walkthrough.mdx
@@ -2,7 +2,7 @@
 
 ## Understanding the basics
 
-Before getting into the this topic, first you should understand the `vim.tbl_deep_extend` function which is used for merging tables and their values recursively.  
+Before getting into the topic, first you should understand the `vim.tbl_deep_extend` function which is used for merging tables and their values recursively.  
 
 - The function `vim.tbl_deep_extend` is normally used to merge 2 tables, and its syntax looks like this: 
 

--- a/src/routes/(index)/docs/quickstart/learn-lua.mdx
+++ b/src/routes/(index)/docs/quickstart/learn-lua.mdx
@@ -114,7 +114,7 @@ local function print_num(a)
   print(a)
 end
 
-or
+-- or
 
 local print_num = function(a)
   print(a)


### PR DESCRIPTION
Fixes some typos and updates a recommended path to the correct one.

The files to avoid saving into lives under `lua/plugins/*`, not inside `custom/plugins/*` (the later is the recommended one to save to).