### PR TITLE
Fixed typo in documentation

### DIFF
--- a/src/routes/(index)/docs/quickstart/learn-lua.mdx
+++ b/src/routes/(index)/docs/quickstart/learn-lua.mdx
@@ -247,7 +247,7 @@ Import code from other files
 require("path")
 
 -- for example in ~/.config/nvim/lua , all dirs and files are accessable via require
--- Do know that all files in that lua folder are in path!
+-- Do note that all files in that lua folder are in path!
 -- ~/.config/nvim/lua/custom 
 -- ~/.config/nvim/lua/custom/init.lua
 


### PR DESCRIPTION
Although "Do know" is technically an OK phrase, the "Do note" is used much more. Since "know" and "note" are pronounced very similarly, I think this was a typo.
