### PR TITLE
Rephrased sentence & fixed British word in doc

### DIFF
--- a/src/routes/(index)/docs/config/walkthrough.mdx
+++ b/src/routes/(index)/docs/config/walkthrough.mdx
@@ -29,7 +29,7 @@ local result = vim.tbl_deep_extend("force", person, someone)
 ```
 
 <br />
-Its usage can even be used in more complex tables. As said, it works recursively, which means that it will apply the same behaviour for nested table values: 
+Its usage can be used in even more complex tables. As was mentioned before, it works recursively, which means that it will apply the same behavior for nested table values:
 
 ```lua
 local person = {


### PR DESCRIPTION
> Its usage can even be used in more complex tables.

"Even" can have different meanings based on the location in a sentence. Here it means that "it not only can be used in simple tables, but in [...] comples ones too.". But the goal is to say "this is not so complex table, but it works on even/much more complex tables.". Hence, the location of the "even" should be changed.

> As said, it works recursively, which means that it will apply the same behaviour for nested table values:

"As said," is definitely missing something here:

- "As I said,"
- "As was said previously,"
- "As was mentioned before,"
- "As was previously mentioned,"

In any case, a different variant should be chosen. I chose one of the well known (to me) variants: "As was mentioned before,".
