### PR TITLE
Correct path to install Nvchad on Windows

### DIFF
--- a/src/components/docpage/install.jsx
+++ b/src/components/docpage/install.jsx
@@ -7,11 +7,11 @@ const unix_cmd =
   "git clone https://github.com/NvChad/NvChad ~/.config/nvim --depth 1 && nvim";
 
 const windows_cmd = [
-  "git clone https://github.com/NvChad/NvChad $HOME\\AppData\\Local\\nvim --depth 1 && nvim",
+  "git clone https://github.com/NvChad/NvChad %USERPROFILE%\\AppData\\Local\\nvim --depth 1 && nvim",
   `# if the above path doesnt work, try any of these paths :\n
 %LOCALAPPDATA%\\nvim\ \n
-%USERPROFILE%\AppData\Local\\nvim \n
-C:\Users\%USERNAME%\AppData\Local\\nvim`,
+%USERPROFILE%\\AppData\\Local\\nvim \n
+C:\Users\\%USERNAME%\\AppData\\Local\\nvim`,
 ];
 
 export const docker_cmd =

--- a/src/components/docpage/install.jsx
+++ b/src/components/docpage/install.jsx
@@ -10,7 +10,6 @@ const windows_cmd = [
   "git clone https://github.com/NvChad/NvChad %USERPROFILE%\\AppData\\Local\\nvim --depth 1 && nvim",
   `# if the above path doesnt work, try any of these paths :\n
 %LOCALAPPDATA%\\nvim\ \n
-%USERPROFILE%\\AppData\\Local\\nvim \n
 C:\Users\\%USERNAME%\\AppData\\Local\\nvim`,
 ];
 


### PR DESCRIPTION
On the website, the correct path to `%localappdata%\nvim` for Windows is `AppData\Local\nvim` and not `AppDataLocal\nvim` just a little mistake on the install instructions of the nvchad website:

> if the above path doesnt work, try any of these paths :
> 
> %LOCALAPPDATA%\nvim 
> 
> %USERPROFILE%AppDataLocal\nvim 
> 
> C:Users%USERNAME%AppDataLocal\nvim

For my case, I do this, which works perfectly:
`git clone https://github.com/NvChad/NvChad %USERPROFILE%\AppData\Local\nvim --depth 1 && nvim `

All the best!