### PR TITLE
separate Windows Install for CMD and PowerShell

### DIFF
--- a/src/components/docpage/install.jsx
+++ b/src/components/docpage/install.jsx
@@ -7,10 +7,17 @@ const unix_cmd =
   "git clone https://github.com/NvChad/NvChad ~/.config/nvim --depth 1 && nvim";
 
 const windows_cmd = [
-  "git clone https://github.com/NvChad/NvChad %USERPROFILE%\\AppData\\Local\\nvim --depth 1 && nvim",
+  `# if you're using Command Prompt(CMD) \n
+git clone https://github.com/NvChad/NvChad %USERPROFILE%\\AppData\\Local\\nvim --depth 1 && nvim`,
+  `# if you're using PowerShell(pwsh) \n
+git clone https://github.com/NvChad/NvChad $ENV:USERPROFILE\\AppData\\Local\\nvim --depth 1 && nvim`,
   `# if the above path doesnt work, try any of these paths :\n
+# for CMD
 %LOCALAPPDATA%\\nvim\ \n
-C:\Users\\%USERNAME%\\AppData\\Local\\nvim`,
+C:\\Users\\%USERNAME%\\AppData\\Local\\nvim \n
+# for PowerShell
+$ENV:LOCALAPPDATA\\nvim\ \n
+C:\\Users\\$ENV:USERNAME\\AppData\\Local\\nvim`,
 ];
 
 export const docker_cmd =

--- a/src/routes/(index)/docs/quickstart/install.mdx
+++ b/src/routes/(index)/docs/quickstart/install.mdx
@@ -28,7 +28,11 @@ To update NvChad run the following command :
 rm -rf ~/.config/nvim
 rm -rf ~/.local/share/nvim
 
-# Windows
+# Windows CMD
 rd -r ~\AppData\Local\nvim
 rd -r ~\AppData\Local\nvim-data
+
+# Window PowerShell
+rm -Force ~\AppData\Local\nvim
+rm -Force ~\AppData\Local\nvim-data
 ```


### PR DESCRIPTION
This separate install command for PowerShell users and cmd users, so they don't mess up.

also correct path at
`C:\Users\\%USERNAME%\\AppData\\Local\\nvim \n`
to 
`C:\\Users\\%USERNAME%\\AppData\\Local\\nvim \n`