### PR TITLE
added clarification on how to remove `<tab> ` keymap in the faq

### DIFF
--- a/src/routes/docs/faq.mdx
+++ b/src/routes/docs/faq.mdx
@@ -25,12 +25,21 @@
 
 - In Nvchad `<Tab> & <S-Tab>` are mapped by default and nvim maps to `<C-i>` if `<Tab>` key is mapped. [Check](https://stackoverflow.com/questions/16209213/vim-jump-forward-with-c-i-doesnt-work-for-me-too-snipmate/16209534#16209534)
 
-- To map those keys, you should either disable `<Tab>` in your custom mappings file or have certain settings in your terminal config, for exampele:  alacritty config : 
+- To map those keys, you should either disable `<Tab>` in your custom mappings file or have certain settings in your terminal config, for example:  alacritty config : 
 
 ```bash
 key_bindings:
    - { key: I, mods: Control, chars: "\x1b[105;6u" }
  ```
+
+- **NOTE**: keymaps in NvChad are case sensitive, to delete it you need to use lowercase `<tab>`. Add this to your mappings.lua:
+```lua
+M.disabled = {
+	n = {
+		["<tab>"] = "",
+	},
+}
+```
 
 ## NvChad's color is weird
 

--- a/src/routes/docs/faq.mdx
+++ b/src/routes/docs/faq.mdx
@@ -33,6 +33,7 @@ key_bindings:
  ```
 
 - **NOTE**: keymaps in NvChad are case sensitive, to delete it you need to use lowercase `<tab>`. Add this to your mappings.lua:
+
 ```lua
 M.disabled = {
 	n = {


### PR DESCRIPTION
The faq was not easy to follow, because the docs mention `<Tab>` while the keymap is lowercase `<tab>` and `:nmap` also reported uppercase `<Tab>`.

I added a note to clarify that to remove the keymap lowercase `<tab>` has to be added to the disabled mappings.
I also added a sample config which can directly be copy pasted into `mappings.lua`