### PR TITLE
fix: quickstart broken link in v2.5 news

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Built using [SolidJS](https://www.solidjs.com/) + [UnoCSS](https://unocss.dev/) 
 
 # Contributing 
 
-The docs (markdown files) are [here](https://github.com/NvChad/nvchad.github.io/tree/src/src/routes/(index)/docs). Feel free to send PR's regarding spelling mistakes, incorrect grammar etc.
+The docs (markdown files) are [here](https://github.com/NvChad/nvchad.github.io/tree/main/src/routes/docs). Feel free to send PR's regarding spelling mistakes, incorrect grammar etc.
 
 # Credits
 
-- Huge Thanks to [@mdynnl](https://github.com/mdynnl) for helping me integreating solid-start and solid-ssg in this site.
+- Huge Thanks to [@mdynnl](https://github.com/mdynnl) for helping me to integrate solid-start and solid-ssg in this 
+  site.

--- a/src/routes/news/v2.5_release.mdx
+++ b/src/routes/news/v2.5_release.mdx
@@ -54,7 +54,7 @@ export const meta = {
 
 ## Migration
 
-- Check the [Quick walkthrough doc](http://localhost:3000/docs/config/walkthrough) for having a basic understanding of how NvChad works now.
+- Check the [Quick walkthrough doc](/docs/config/walkthrough) for having a basic understanding of how NvChad works now.
 - git clone [starter repo](https://github.com/NvChad/starter) as your nvim config.
 - Go through the new [module structure of nvchad](https://github.com/NvChad/NvChad/tree/v2.5) which will be used as your plugin.
 - You can use this [shell script](https://gist.github.com/siduck/048bed2e7570569e6b327b35d1715404) ( unix only ) to automate your migration.


### PR DESCRIPTION
Hello!

I've just created a pull request addressing a couple of issues:

* In v2.5 news, the _Quick Walkthrough_ link was pointing to localhost.
* Fixed Broken Docs Link: The README file had a broken link to the documentation, which is now resolved.
* Grammar and Spelling Corrections: Also, I've taken the liberty to correct some spelling errors and improve the grammar in the last sentence for better clarity.

Please review the changes and let me know if any further adjustments are needed.

Thanks!