### PR TITLE
added docs for dockerised nvchad setup and usage, it allows users to use NV_CHAD in dockerised manner with all the data and projects persisting in docker volumes

### DIFF
--- a/src/components/docpage/install.tsx
+++ b/src/components/docpage/install.tsx
@@ -44,6 +44,33 @@ export const osInfos = [
   nvim
   '`,
   },
+  {
+    name: "persistent docker",
+    icon: "i-nonicons:docker-16",
+    cmds: (
+      <>
+        <li>Clone the repo</li>
+
+        <pre class="hljs">
+          git clone https://github.com/P-Y-R-O-B-O-T/DOCKERIZED_NVCHAD.git && cd DOCKERIZED_NVCHAD
+        </pre>
+
+        <li>Setup things</li>
+
+        <pre class="hljs">
+          chmod +x install.sh && ./install.sh
+        </pre>
+
+        <li>Run It</li>
+
+        <pre class="hljs">
+          doc_nvchad
+        </pre>
+
+        <li>For more help visit https://github.com/P-Y-R-O-B-O-T/DOCKERIZED_NVCHAD</li>
+      </>
+    ),
+  },
 ];
 
 export const [os, setOS] = createSignal(osInfos[0]);


### PR DESCRIPTION
We were discussing about the contribution for persistent docker NV_CHAD in the discussion

https://github.com/NvChad/nvchad.github.io/discussions/209

All the tasks are complete and it is ready to merge from my side

Kindly verify the same from your side and merge

Hoping all goes well