### PR TITLE
Fixing wrong behavior on ThemeToggleBtn

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal } from "solid-js";
+import { createEffect, createSignal, onMount } from "solid-js";
 import { mobSideBar, setMobSidebar } from "~/components/doc_comps/Sidebar";
 
 import docsearch from "@docsearch/js";
@@ -36,9 +36,12 @@ function Links() {
 }
 
 export const ThemeToggleBtn = (props) => {
-  const [theme, setTheme] = createSignal(
-    (globalThis.localStorage && localStorage.theme) || "light",
-  );
+  const [theme, setTheme] = createSignal("light");
+
+  onMount(() => {
+    const localTheme = localStorage.theme
+    setTheme(localTheme)
+  })
 
   return (
     <button


### PR DESCRIPTION
Basically, when you set dark as your theme preference, if you refresh the page it comes back with the icon of light version, instead of the dark one.

With this pr, this behavior is fixed.

Its not the best solution, but it fix it. I had a hard time trying to get local storage value on this component first render, as it behav as a server component.

Wrong behavior that its been fixed:

![image](https://github.com/NvChad/nvchad.github.io/assets/40671286/7a0fe39e-8121-4bf2-b460-bb54422f5d42)
