### PR TITLE
Bugfix/theme initial state

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -36,7 +36,7 @@ function Links() {
 }
 
 export const ThemeToggleBtn = (props) => {
-  const [theme, setTheme] = createSignal("light");
+  const [theme, setTheme] = createSignal("");
 
   onMount(() => {
     const localTheme = localStorage.theme

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -39,9 +39,9 @@ export const ThemeToggleBtn = (props) => {
   const [theme, setTheme] = createSignal("");
 
   onMount(() => {
-    const localTheme = localStorage.theme
-    setTheme(localTheme)
-  })
+    const localTheme = localStorage.theme;
+    setTheme(localTheme);
+  });
 
   return (
     <button

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -6,7 +6,7 @@ export default createHandler(() => (
       <html lang="en">
         <head>
           <meta charset="utf-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1" /> 
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
 
           {/* favicon & font */}
           <link rel="icon" type="image/svg+xml" href="/logo.svg" />
@@ -28,7 +28,7 @@ export default createHandler(() => (
           <script>
             if (!localStorage.theme)
               localStorage.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-            document.querySelector("html").className = localStorage.theme
+            document.querySelector("html").className = localStorage.theme;
           </script>
         </head>
         <body>

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -24,8 +24,10 @@ export default createHandler(() => (
 
           {assets}
 
-          {/* set saved theme  */}
+          {/* Check if a theme is saved in localStorage, if not, set it based on the system's theme preference */}
           <script>
+            if (!localStorage.theme)
+              localStorage.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
             document.querySelector("html").className = localStorage.theme
           </script>
         </head>


### PR DESCRIPTION
### Issue:
The website currently attempts to set the theme from `localStorage` without checking if a value is actually stored. This can lead to `undefined` being used as the theme, causing unexpected behavior e.g. having to double click the theme-toggler to get to dark mode.

### Steps to Reproduce:
1. Clear cookies on the official website (https://nvchad.com).
2. Reload the page.

### Expected Behavior:
The website should load with a valid theme applied, even if no theme preference is set in `localStorage` yet.

### Proposed Fix:
This pull request introduces a check for `localStorage.theme`. If the value is not set (i.e., `undefined`), the system's preferred theme will be used as the default and saved to `localStorage` for future visits.

_Manual testing has been conducted to ensure the fix works as intended._