### PR TITLE
docs: update faq mapping ctrl i/o example for v2.5 structure

### DIFF
--- a/src/routes/docs/faq.mdx
+++ b/src/routes/docs/faq.mdx
@@ -40,11 +40,10 @@ key_bindings:
 - **NOTE**: keymaps in NvChad are case-sensitive, to delete it you need to use lowercase `<tab>`. Add this to your mappings.lua:
 
 ```lua
-M.disabled = {
-	n = {
-		["<tab>"] = "",
-	},
-}
+-- Disable mappings
+local nomap = vim.keymap.del
+
+nomap("n", "<tab>")
 ```
 
 ## NvChad's color is weird


### PR DESCRIPTION
Updated the FAQ page "Mapping Ctrl + o / i keys" section to be compatible with the config structure changes that were made in the v2.5 release.