### PR TITLE
remove feature comment.nvim since it removed from nvchad

### DIFF
--- a/src/routes/docs/features.mdx
+++ b/src/routes/docs/features.mdx
@@ -131,6 +131,5 @@ export const meta = {
 - [`blankline`](https://github.com/lukas-reineke/indent-blankline.nvim) - Indent guides for Neovim i.e indentline plugin.
 - [`gitsigns.nvim`](https://github.com/lewis6991/gitsigns.nvim) - Git integration for buffers
 - [`nvim-autopairs`](https://github.com/windwp/nvim-autopairs)
-- [`comment.nvim`](https://github.com/numToStr/Comment.nvim) - Commenting plugin
 - [`mason.nvim`](https://github.com/williamboman/mason.nvim) - Portable package manager for Neovim that runs everywhere Neovim runs. Easily install and manage LSP servers, DAP servers, linters, and formatters.
 - [`conform.nvim`](https://github.com/stevearc/conform.nvim) - Lightweight yet powerful formatter plugin for Neovim


### PR DESCRIPTION
Since NvChad issue [#2861](https://github.com/NvChad/NvChad/pull/2861) removed the comment.nvim plugin.