### PR TITLE
fix: fix 'ui plugin docs' link at features page

### DIFF
--- a/src/routes/docs/features.mdx
+++ b/src/routes/docs/features.mdx
@@ -60,7 +60,7 @@ export const meta = {
 - All of the above functions allow floating, horizontal, vertical windows
 - Each window can have its own cmd/size/cmd/ highlight group
 - Using it with our telescope picker ( :Telescope terms ) to unhide terminal buffers <kbd> leader + pt </kbd>.
-- Check (ui plugin docs)[nvchad.com/docs/config/nvchad_ui#term]
+- Check [ui plugin docs](nvchad.com/docs/config/nvchad_ui#term)
 
 <div class="iframe-container">
 <iframe src="https://www.youtube.com/embed/3DysWI_6YpQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow="fullscreen;"></iframe>


### PR DESCRIPTION
There's a wrong link on the features page. This PR fixes the markdown format to fix the "UI plugin docs" link on the Features page.