### PR TITLE
ui plugin docs: add theme and separator_style to example

### DIFF
--- a/src/routes/docs/config/nvchad_ui.mdx
+++ b/src/routes/docs/config/nvchad_ui.mdx
@@ -43,7 +43,13 @@ M.ui = {
       cursor = function()
         return "%#BruhHl#" .. " bruh " -- the highlight group here is BruhHl,
       end
-    }
+    },
+
+    -- Separator style and theme
+    theme = "default", -- default, vscode, vscode_colored or minimal
+    -- default, round, block, and arrow are supported only by the default statusline theme.
+    -- the round and block separators are also supported by the minimal theme.
+    separator_style = "default", -- default, round, block or arrow
   }
 }
 ```


### PR DESCRIPTION
Added an example of how to change the statusline theme and separator style