### PR TITLE
docs: fix 'window powershell' typo and change 'Macos' to 'MacOS'

### DIFF
--- a/src/routes/docs/quickstart/install.mdx
+++ b/src/routes/docs/quickstart/install.mdx
@@ -31,7 +31,7 @@ import OS_Selector from "~/components/docpage/install";
 ## Uninstall
 
 ```bash
-# Linux / Macos (unix)
+# Linux / MacOS (unix)
 rm -rf ~/.config/nvim
 rm -rf ~/.local/state/nvim
 rm -rf ~/.local/share/nvim
@@ -45,7 +45,7 @@ rm -rf ~/.var/app/io.neovim.nvim/.local/state/nvim
 rd -r ~\AppData\Local\nvim
 rd -r ~\AppData\Local\nvim-data
 
-# Window PowerShell
+# Windows PowerShell
 rm -Force ~\AppData\Local\nvim
 rm -Force ~\AppData\Local\nvim-data
 ```


### PR DESCRIPTION
This PR fixes a typo where it said 'window' instead of 'windows' and it changes 'Macos' to 'MacOS'.

Changes:
- 'Macos' -> 'MacOS'
- 'Window' -> 'Windows'