### PR TITLE
Update docs link to lsp configs

### DIFF
--- a/src/routes/docs/config/lsp.mdx
+++ b/src/routes/docs/config/lsp.mdx
@@ -7,7 +7,7 @@ export const meta = {
 
 Before starting, it is strongly recommended that you walk through the LSP configuration [lspconfig repository](https://github.com/neovim/nvim-lspconfig).
 
-Then check [server_configurations.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) to make sure your language's LSP server is present there. 
+Then check [configs.md](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md) to make sure your language's LSP server is present there.
 
 - **Plugin table**
 


### PR DESCRIPTION
nvim-lspconfig moved the configs.md file in their docs. Update the link to the new file location