### PR TITLE
fix: modified iframe tags to allow fullscreen youtube mode

### DIFF
--- a/src/routes/docs/features.mdx
+++ b/src/routes/docs/features.mdx
@@ -22,7 +22,7 @@ export const meta = {
 - In the below video, you can see that the chadrc file's ( user config ) UI related options reload on the fly 
 
 <div class="iframe-container">
-  <iframe src="https://www.youtube.com/embed/xytzreFq_us" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow="fullscreen"></iframe>
+  <iframe src="https://www.youtube.com/embed/xytzreFq_us" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 ## Theme switcher
@@ -48,7 +48,7 @@ export const meta = {
 - Think of it like workspaces on Linux/Windows where windows stay in their own workspaces, but in vim buffers from all tabs will be shown in every tab!
 
 <div class="iframe-container">
-<iframe src="https://www.youtube.com/embed/V_9iJ96U_k8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow="fullscreen;"></iframe>
+<iframe src="https://www.youtube.com/embed/V_9iJ96U_k8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 ## Term 
@@ -64,7 +64,7 @@ export const meta = {
 - Check [ui plugin docs](https://nvchad.com/docs/config/nvchad_ui#term)
 
 <div class="iframe-container">
-<iframe src="https://www.youtube.com/embed/3DysWI_6YpQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow="fullscreen;"></iframe>
+<iframe src="https://www.youtube.com/embed/3DysWI_6YpQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 
@@ -85,7 +85,7 @@ export const meta = {
 - command to toggle it : `NvCheatsheet` and mapping `leader + ch`
 
 <div class="iframe-container">
-<iframe src="https://www.youtube.com/embed/IljDD4cjgKc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow='fullscreen;'></iframe>
+<iframe src="https://www.youtube.com/embed/IljDD4cjgKc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 ## Colorify
@@ -159,7 +159,7 @@ check `:h nvui.mason` for more info
 
 - [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) is used along with cmp for completion and [`luasnip`](https://github.com/L3MON4D3/LuaSnip)  + [`friendly-snippets`](https://github.com/rafamadriz/friendly-snippets) for snippet completion! 
 <div class="iframe-container">
-<iframe src="https://www.youtube.com/embed/oMzMDXA-VO0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow='fullscreen;'></iframe>
+<iframe src="https://www.youtube.com/embed/oMzMDXA-VO0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 <br/>

--- a/src/routes/news/v2.0_release.mdx
+++ b/src/routes/news/v2.0_release.mdx
@@ -62,7 +62,7 @@ So Whats new in this release?
 
 - Now you can live-reload some parts of the UI table in chadrc.
 
-  <iframe src="https://www.youtube.com/embed/xytzreFq_us" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow="fullscreen"></iframe>
+  <iframe src="https://www.youtube.com/embed/xytzreFq_us" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <br/>
 
@@ -96,7 +96,7 @@ So Whats new in this release?
 
 ![nvcheatsheet](/features/nvcheatsheet.webp)
 
-<iframe src="https://www.youtube.com/embed/IljDD4cjgKc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allow='fullscreen;'></iframe>
+<iframe src="https://www.youtube.com/embed/IljDD4cjgKc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Chadrc completion
 


### PR DESCRIPTION
This pr aims to fix the nuance issue where iframe YouTube videos on the docs site are unable to enter fullscreen mode 