### PR TITLE
Update other plugins descriptions

### DIFF
--- a/src/routes/docs/features.mdx
+++ b/src/routes/docs/features.mdx
@@ -165,12 +165,12 @@ check `:h nvui.mason` for more info
 <br/>
 
 ## Other plugins
-- [`lazy.nvim`](https://github.com/folke/lazy.nvim) - A modern plugin manager for Neovim
-- [`whichkey.nvim`](https://github.com/folke/which-key.nvim) - Create key bindings that stick. WhichKey is a lua plugin for Neovim 0.5 that displays a popup with possible keybindings of the command you started typing.
-- [`nvim-colorizer.lua`](https://github.com/NvChad/nvim-colorizer.lua) - Fastest Neovim colorizer, hex colors, hsl codes and much more.
-- [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter) - Nvim Treesitter configurations and abstraction layer, we use it for syntax highlighting & auto-indenting. 
-- [`blankline`](https://github.com/lukas-reineke/indent-blankline.nvim) - Indent guides for Neovim i.e indentline plugin.
-- [`gitsigns.nvim`](https://github.com/lewis6991/gitsigns.nvim) - Git integration for buffers
-- [`nvim-autopairs`](https://github.com/windwp/nvim-autopairs)
+- [`lazy.nvim`](https://github.com/folke/lazy.nvim) - A modern plugin manager for Neovim.
+- [`which-key.nvim`](https://github.com/folke/which-key.nvim) - Create key bindings that stick. WhichKey helps you remember your Neovim keymaps, by showing available keybindings in a popup as you type.
+- [`nvim-colorizer.lua`](https://github.com/NvChad/nvim-colorizer.lua) - The fastest Neovim colorizer.
+- [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter) - Nvim Treesitter configurations and abstraction layer. We use it for syntax highlighting & auto-indenting.
+- [`indent-blankline.nvim`](https://github.com/lukas-reineke/indent-blankline.nvim) - Indent guides for Neovim.
+- [`gitsigns.nvim`](https://github.com/lewis6991/gitsigns.nvim) - Git integration for buffers.
+- [`nvim-autopairs`](https://github.com/windwp/nvim-autopairs) - Autopairs for neovim written in lua.
 - [`mason.nvim`](https://github.com/williamboman/mason.nvim) - Portable package manager for Neovim that runs everywhere Neovim runs. Easily install and manage LSP servers, DAP servers, linters, and formatters.
-- [`conform.nvim`](https://github.com/stevearc/conform.nvim) - Lightweight yet powerful formatter plugin for Neovim
+- [`conform.nvim`](https://github.com/stevearc/conform.nvim) - Lightweight yet powerful formatter plugin for Neovim.


### PR DESCRIPTION
- Update the plugin name to match the repo title
- Update the description after the plugin name to match the about section from the repo

The format is:
`[repoName](linkToRepo) - aboutSectionFromRepo. optionallyWhyWeUsePlugin.`

Updated all plugins listed under Other plugins to match this format

![image](https://github.com/user-attachments/assets/0938cf68-7955-46bb-9827-4588e10d41ca)
