### PR TITLE
Add Build Instructions to README and Update Installation Guide along with Neovim Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Built using [SolidJS](https://www.solidjs.com/) + [UnoCSS](https://unocss.dev/) 
 
 The docs (markdown files) are [here](https://github.com/NvChad/nvchad.github.io/tree/main/src/routes/docs). Feel free to send PR's regarding spelling mistakes, incorrect grammar etc.
 
+# Build
+
+Install [bun](https://bun.sh/), clone the repo and run the following commands:
+
+```bash
+bun install
+bun run dev
+```
+
 # Credits
 
 - Huge Thanks to [@mdynnl](https://github.com/mdynnl) for helping me to integrate solid-start and solid-ssg in this 

--- a/src/components/docpage/install.tsx
+++ b/src/components/docpage/install.tsx
@@ -3,7 +3,7 @@ import create_copyIcon from "~/components/doc_comps/clipboard";
 
 export const osInfos = [
   {
-    name: "linux / macos",
+    name: "Linux",
 
     cmds: (
       <>
@@ -14,7 +14,21 @@ export const osInfos = [
         </pre>
       </>
     ),
-    icon: "i-mingcute:hashtag-fill",
+    icon: "i-uil:linux",
+  },
+
+  {
+    name: "MacOS",
+    icon: "i-wpf:macos",
+    cmds: (
+      <>
+        <pre>
+          <code class="hljs">
+            git clone https://github.com/NvChad/starter ~/.config/nvim && nvim
+          </code>
+        </pre>
+      </>
+    ),
   },
 
   {

--- a/src/components/docpage/neovim-install.tsx
+++ b/src/components/docpage/neovim-install.tsx
@@ -1,0 +1,147 @@
+import { createEffect, createSignal } from "solid-js";
+import create_copyIcon from "~/components/doc_comps/clipboard";
+
+export const osNeovimInstall = [
+  {
+    name: "Arch Linux",
+
+    cmds: (
+      <>
+        Arch Linux users can directly install neovim from the official repositories.
+        <pre>
+          <code class="hljs">
+            sudo pacman -S neovim
+          </code>
+        </pre>
+      </>
+    ),
+    icon: "i-devicon-plain:archlinux",
+  },
+
+  {
+    name: "Gentoo Linux",
+    icon: "i-mdi:gentoo",
+    cmds: (
+      <>
+        Gentoo Linux users can directly install neovim from the official repositories.
+        <pre>
+          <code class="hljs">
+            sudo emerge --av app-editors/neovim
+          </code>
+        </pre>
+      </>
+    ),
+  },
+
+  {
+    name: "Tarball",
+    icon: "i-octicon:file-zip-24",
+    cmds: (
+      <>
+        If you're using a distribution like Debian, Kali Linux, or any other distro that does not have Neovim version >= 0.10.0 in the official repositories, you will need to install it manually or use other third-party package managers. Here is an example of using Neovim v0.10.4.
+        <pre>
+          <code class="hljs">
+
+            {`wget https://github.com/neovim/neovim/releases/download/v0.10.4/nvim-linux-x86_64.tar.gz
+tar -xzvf nvim-linux-x86_64.tar.gz
+sudo mv nvim-linux-x86_64 /usr/local/
+sudo ln -s /usr/local/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim
+
+nvim --version # check neovim version`}
+          </code>
+        </pre>
+      </>
+    ),
+  },
+  
+  {
+      name: "Flatpak",
+      icon: "i-simple-icons:flatpak",
+      cmds: (
+        <>
+          Flatpak users can install Neovim using the flatpak package manager.
+          <pre>
+            <code class="hljs">
+            flatpak install flathub io.neovim.nvim
+            </code>
+          </pre>
+        </>
+      ),
+  },
+
+  {
+      name: "Snap",
+      icon: "i-simple-icons:snapcraft",
+      cmds: (
+        <>
+          Snap users can install Neovim using the snap package manager.
+          <pre>
+            <code class="hljs">
+            sudo snap install nvim
+            </code>
+          </pre>
+        </>
+      ),
+  },
+  
+
+  {
+    name: "Windows",
+    icon: "i-mingcute:windows-fill",
+    cmds: (
+      <>
+        Windows user can install Neovim using the scoop package manager.
+        <pre>
+        <code class="hljs">
+          {`scoop bucket add main
+scoop install neovim`}
+        </code>
+        </pre>
+      </>
+    ),
+    },
+
+  {
+    name: "MacOS",
+    icon: "i-wpf:macos",
+    cmds: (
+      <>
+        MacOS users can install Neovim using the Homebrew package manager.
+        <pre>
+          <code class="hljs">
+            brew install neovim
+          </code>
+        </pre>
+      </>
+    ),
+    },
+
+];
+
+export const [os, setOS] = createSignal(osNeovimInstall[0]);
+
+createEffect(() => {
+  os();
+  create_copyIcon("DocContent");
+});
+
+export default () => (
+  <div flex="~ wrap" gap-5>
+    {osNeovimInstall.map((x) => (
+      <button
+        capitalize="~"
+        onClick={() => setOS(x)}
+        class={
+          os().name == x.name ? "bg-emerald2 dark:bg-sky3 dark:text-black" : ""
+        }
+      >
+        <div class={x.icon}></div> {x.name}
+      </button>
+    ))}
+
+    <div w="full" grid="~ gap4">
+      {os()?.cmd && <pre class="hljs">{os()?.cmd}</pre>}
+      {os()?.cmds && os().cmds}
+    </div>
+  </div>
+);

--- a/src/routes/docs/quickstart/install.mdx
+++ b/src/routes/docs/quickstart/install.mdx
@@ -4,10 +4,12 @@ export const meta = {
 };
 
 import OS_Selector from "~/components/docpage/install";
+import Neovim_Installl from "~/components/docpage/neovim-install";
 
 ## Pre-requisites
 
-- [Neovim 0.10](https://github.com/neovim/neovim/releases/tag/v0.10.0).
+- Git, For cloning NvChad repository.
+- [Neovim >= 0.10](https://github.com/neovim/neovim/tags).
 - [Nerd Font](https://www.nerdfonts.com/) as your terminal font.
   - Make sure the nerd font you set doesn't end with <strong>Mono</strong> to prevent small icons. 
   - <strong>Example : </strong> JetbrainsMono Nerd Font and not **<s>JetbrainsMono Nerd Font Mono</s>**
@@ -16,7 +18,11 @@ import OS_Selector from "~/components/docpage/install";
 - Make, Windows users must have [`GnuWin32`](https://sourceforge.net/projects/gnuwin32) installed and set on path.
 - Delete old neovim folders (check commands below)
 
-## Install
+## Install Neovim
+
+<Neovim_Installl/>
+
+## Install NvChad
 
 <OS_Selector/>
 
@@ -25,11 +31,11 @@ import OS_Selector from "~/components/docpage/install";
 - Delete the `.git` folder from nvim folder.
 - Learn customization of ui & base46 from `:h nvui`.
 
-## Update
+## Update NvChad
 
 - `Lazy sync` command
 
-## Uninstall
+## Uninstall NvChad
 
 ```bash
 # Linux / MacOS (unix)


### PR DESCRIPTION
I added build instructions to the README and added neovim installation guide of each os or some distro

- Splitting the Linux/macOS section into two.
- Added Git as a prerequisite for cloning NvChad.
- Added new component for Neovim installation.
- Update the header to specify NvChad.

## Preview changed screenshot

![Screenshot 2025-03-19 at 05-18-44 NvChad Installation](https://github.com/user-attachments/assets/8dcd5689-ed58-4351-91a3-b479d05dd0c6)
