### PR TITLE
install.tsx: Use ~/.config only if $XDG_CONFIG_HOME is undefined

### DIFF
--- a/src/components/docpage/install.tsx
+++ b/src/components/docpage/install.tsx
@@ -9,7 +9,7 @@ export const osInfos = [
       <>
         <pre>
           <code class="hljs">
-            git clone https://github.com/NvChad/starter ~/.config/nvim && nvim
+            git clone https://github.com/NvChad/starter "${XDG_CONFIG_HOME:-$HOME/.config}/nvim" && nvim
           </code>
         </pre>
       </>


### PR DESCRIPTION
Took me a while to debug this on macOS where I've a custom directory for configs.