### PR TITLE
fix(quickstart): typos on install page

### DIFF
--- a/src/routes/docs/quickstart/install.mdx
+++ b/src/routes/docs/quickstart/install.mdx
@@ -10,9 +10,9 @@ import OS_Selector from "~/components/docpage/install";
 - [Neovim 0.11](https://github.com/neovim/neovim/releases/tag/stable).
 - [Nerd Font](https://www.nerdfonts.com/) as your terminal font.
   - Make sure the nerd font you set doesn't end with <strong>Mono</strong> to prevent small icons. 
-  - <strong>Example : </strong> JetbrainsMono Nerd Font and not **<s>JetbrainsMono Nerd Font Mono</s>**
+  - <strong>Example : </strong> JetBrainsMono Nerd Font and not **<s>JetBrainsMono Nerd Font Mono</s>**
   - The *Mono fonts would work too but icons will slightly look smaller. 
-- [Tree-sitter-cli](https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md) is requied by nvim-treesitter plugin to install parsers.
+- [Tree-sitter-cli](https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md) is required by nvim-treesitter plugin to install parsers.
 - [Ripgrep](https://github.com/BurntSushi/ripgrep) is required for grep searching with Telescope <strong>(OPTIONAL)</strong>. 
 - GCC, Windows users must have [`mingw`](http://mingw-w64.org/downloads) installed and set on path.
 - Make, Windows users must have [`GnuWin32`](https://sourceforge.net/projects/gnuwin32) installed and set on path.


### PR DESCRIPTION
- "requied" -> "requi**r**ed"
- capitalization of `JetBrainsMono`